### PR TITLE
[REFACTOR] 북마크 조회 시 JOIN FETCH 사용하여 쿼리 성능 개선 

### DIFF
--- a/src/main/java/org/wefresh/wefresh_server/bookmark/repository/BookmarkRepository.java
+++ b/src/main/java/org/wefresh/wefresh_server/bookmark/repository/BookmarkRepository.java
@@ -3,15 +3,45 @@ package org.wefresh.wefresh_server.bookmark.repository;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 import org.wefresh.wefresh_server.bookmark.domain.Bookmark;
 
 import java.util.List;
+import java.util.Optional;
 
 public interface BookmarkRepository extends JpaRepository<Bookmark, Long> {
 
     void deleteByUserId(Long userId);
 
+    @Query(value = """
+        SELECT b FROM Bookmark b
+        LEFT JOIN FETCH b.recipe
+        LEFT JOIN FETCH b.todayRecipe
+        WHERE b.user.id = :userId
+        ORDER BY b.createdAt DESC
+    """, countQuery = """
+        SELECT COUNT(b) FROM Bookmark b
+        WHERE b.user.id = :userId
+    """)
     List<Bookmark> findByUserId(Long userId, Pageable pageable);
 
+    @Query(value = """
+        SELECT b FROM Bookmark b
+        LEFT JOIN FETCH b.recipe
+        LEFT JOIN FETCH b.todayRecipe
+        WHERE b.user.id = :userId
+        ORDER BY b.createdAt DESC
+    """, countQuery = """
+        SELECT COUNT(b) FROM Bookmark b
+        WHERE b.user.id = :userId
+    """)
     Page<Bookmark> findByUserIdOrderByCreatedAtDesc(Long userId, Pageable pageable);
+
+    @Query("""
+        SELECT b FROM Bookmark b
+        LEFT JOIN FETCH b.recipe r
+        LEFT JOIN FETCH b.todayRecipe t
+        WHERE b.id = :bookmarkId
+    """)
+    Optional<Bookmark> findById(Long bookmarkId);
 }


### PR DESCRIPTION
## 📚개요
[//]: # (해당하는 이슈 번호 달아주기)
- closed #39

## 💡Key Changes
- 북마크를 조회할 때 Recipe와 TodayRecipe도 한 번에 불러오게 함으로써 (JOIN FETCH) 쿼리 성능을 개선하였습니다.
- Recipe와 TodayRecipe 중 하나는 반드시 null 이기 때문에 LEFT JOIN 이용하였습니다.


## 🎓Reference

