### PR TITLE
[FEAT] 레시피 추천 시 DALL-E 연동하여 이미지 생성 후 S3 업로드

### DIFF
--- a/src/main/java/org/wefresh/wefresh_server/openAi/controller/OpenAiController.java
+++ b/src/main/java/org/wefresh/wefresh_server/openAi/controller/OpenAiController.java
@@ -7,8 +7,8 @@ import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 import org.wefresh.wefresh_server.common.auth.annotation.UserId;
 import org.wefresh.wefresh_server.common.dto.ResponseDto;
-import org.wefresh.wefresh_server.openAi.dto.response.RecommendRecipesDto;
-import org.wefresh.wefresh_server.openAi.dto.response.TodayRecipesDto;
+import org.wefresh.wefresh_server.openAi.dto.response.gpt.RecommendRecipesDto;
+import org.wefresh.wefresh_server.openAi.dto.response.gpt.TodayRecipesDto;
 import org.wefresh.wefresh_server.openAi.service.OpenAiService;
 
 import java.util.List;

--- a/src/main/java/org/wefresh/wefresh_server/openAi/dto/request/DalleRequestDto.java
+++ b/src/main/java/org/wefresh/wefresh_server/openAi/dto/request/DalleRequestDto.java
@@ -1,0 +1,18 @@
+package org.wefresh.wefresh_server.openAi.dto.request;
+
+public record DalleRequestDto(
+        String model,
+        String prompt,
+        int n, // 생성할 이미지 개수
+        String size // 이미지 크기 (예: "1024x1024")
+) {
+    public static DalleRequestDto of(String prompt) {
+        return new DalleRequestDto(
+                "dall-e-2",
+                prompt,
+                1, // 한 개의 이미지 생성
+                "256x256"
+        );
+    }
+}
+

--- a/src/main/java/org/wefresh/wefresh_server/openAi/dto/response/dalle/DalleResponseDto.java
+++ b/src/main/java/org/wefresh/wefresh_server/openAi/dto/response/dalle/DalleResponseDto.java
@@ -1,0 +1,13 @@
+package org.wefresh.wefresh_server.openAi.dto.response.dalle;
+
+import java.util.List;
+
+public record DalleResponseDto(
+        List<DataDto> data
+) {
+    public record DataDto(
+            String url // 생성된 이미지 URL
+    ) {
+    }
+}
+

--- a/src/main/java/org/wefresh/wefresh_server/openAi/dto/response/gpt/GptRecipeResponseDto.java
+++ b/src/main/java/org/wefresh/wefresh_server/openAi/dto/response/gpt/GptRecipeResponseDto.java
@@ -1,4 +1,4 @@
-package org.wefresh.wefresh_server.openAi.dto.response;
+package org.wefresh.wefresh_server.openAi.dto.response.gpt;
 
 import org.wefresh.wefresh_server.openAi.util.JsonUtil;
 

--- a/src/main/java/org/wefresh/wefresh_server/openAi/dto/response/gpt/GptResponseDto.java
+++ b/src/main/java/org/wefresh/wefresh_server/openAi/dto/response/gpt/GptResponseDto.java
@@ -1,4 +1,4 @@
-package org.wefresh.wefresh_server.openAi.dto.response;
+package org.wefresh.wefresh_server.openAi.dto.response.gpt;
 
 import org.wefresh.wefresh_server.openAi.dto.MessageDto;
 

--- a/src/main/java/org/wefresh/wefresh_server/openAi/dto/response/gpt/IngredientDto.java
+++ b/src/main/java/org/wefresh/wefresh_server/openAi/dto/response/gpt/IngredientDto.java
@@ -1,4 +1,4 @@
-package org.wefresh.wefresh_server.openAi.dto.response;
+package org.wefresh.wefresh_server.openAi.dto.response.gpt;
 
 import org.wefresh.wefresh_server.food.domain.Food;
 

--- a/src/main/java/org/wefresh/wefresh_server/openAi/dto/response/gpt/RecommendRecipeDto.java
+++ b/src/main/java/org/wefresh/wefresh_server/openAi/dto/response/gpt/RecommendRecipeDto.java
@@ -1,4 +1,4 @@
-package org.wefresh.wefresh_server.openAi.dto.response;
+package org.wefresh.wefresh_server.openAi.dto.response.gpt;
 
 import org.wefresh.wefresh_server.food.domain.Food;
 import org.wefresh.wefresh_server.recipe.domain.Recipe;

--- a/src/main/java/org/wefresh/wefresh_server/openAi/dto/response/gpt/RecommendRecipesDto.java
+++ b/src/main/java/org/wefresh/wefresh_server/openAi/dto/response/gpt/RecommendRecipesDto.java
@@ -1,4 +1,4 @@
-package org.wefresh.wefresh_server.openAi.dto.response;
+package org.wefresh.wefresh_server.openAi.dto.response.gpt;
 
 import org.wefresh.wefresh_server.food.domain.Food;
 import org.wefresh.wefresh_server.recipe.domain.Recipe;

--- a/src/main/java/org/wefresh/wefresh_server/openAi/dto/response/gpt/TodayRecipeDto.java
+++ b/src/main/java/org/wefresh/wefresh_server/openAi/dto/response/gpt/TodayRecipeDto.java
@@ -1,6 +1,5 @@
-package org.wefresh.wefresh_server.openAi.dto.response;
+package org.wefresh.wefresh_server.openAi.dto.response.gpt;
 
-import org.wefresh.wefresh_server.recipe.domain.Recipe;
 import org.wefresh.wefresh_server.todayRecipe.domain.TodayRecipe;
 
 import java.util.List;

--- a/src/main/java/org/wefresh/wefresh_server/openAi/dto/response/gpt/TodayRecipesDto.java
+++ b/src/main/java/org/wefresh/wefresh_server/openAi/dto/response/gpt/TodayRecipesDto.java
@@ -1,6 +1,5 @@
-package org.wefresh.wefresh_server.openAi.dto.response;
+package org.wefresh.wefresh_server.openAi.dto.response.gpt;
 
-import org.wefresh.wefresh_server.recipe.domain.Recipe;
 import org.wefresh.wefresh_server.todayRecipe.domain.TodayRecipe;
 
 import java.util.List;

--- a/src/main/java/org/wefresh/wefresh_server/openAi/service/DallEService.java
+++ b/src/main/java/org/wefresh/wefresh_server/openAi/service/DallEService.java
@@ -1,0 +1,60 @@
+package org.wefresh.wefresh_server.openAi.service;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+import org.springframework.web.client.RestTemplate;
+import org.wefresh.wefresh_server.external.service.s3.S3Service;
+import org.wefresh.wefresh_server.openAi.dto.request.DalleRequestDto;
+import org.wefresh.wefresh_server.openAi.dto.request.GptRequestDto;
+import org.wefresh.wefresh_server.openAi.dto.response.dalle.DalleResponseDto;
+import org.wefresh.wefresh_server.openAi.dto.response.gpt.GptResponseDto;
+
+import java.io.IOException;
+
+@Service
+@RequiredArgsConstructor
+public class DallEService {
+    @Value("${dalle.api-url}")
+    private String dalleApiUrl;
+
+    @Value("${openai.api-url}")
+    private String apiURL;
+
+    private final RestTemplate restTemplate;
+    private final S3Service s3Service; // S3 업로드 서비스 추가
+
+    public String generateAndUploadImage(String recipeName) {
+        String translatedPrompt = translateToEnglish(recipeName);
+        System.out.println("translatedPrompt = " + translatedPrompt);
+
+        // DALL·E에 요청
+        DalleRequestDto request = DalleRequestDto.of(translatedPrompt);
+        DalleResponseDto response = restTemplate.postForObject(dalleApiUrl, request, DalleResponseDto.class);
+
+        if (response == null || response.data() == null || response.data().isEmpty()) {
+            return "defaultImageURL";  // DALL·E 이미지 생성 실패 시 기본 이미지 반환
+        }
+
+        String dallEImageUrl = response.data().get(0).url(); // DALL·E 이미지 URL
+        return uploadToS3(dallEImageUrl, recipeName); // S3 업로드 후 URL 반환
+    }
+
+    private String uploadToS3(String imageUrl, String recipeName) {
+        try {
+            return s3Service.uploadImageFromUrl("recipes/", imageUrl, recipeName);
+        } catch (IOException e) {
+            e.printStackTrace();
+            return "defaultImageURL"; // 업로드 실패 시 기본 이미지 반환
+        }
+    }
+
+    public String translateToEnglish(String koreanPrompt) {
+        String gptPrompt = "Translate the following food name to English. Return only the translated food name without any additional text: " + koreanPrompt;
+        GptRequestDto request = GptRequestDto.of("gpt-4o-mini", gptPrompt);
+        GptResponseDto response = restTemplate.postForObject(apiURL, request, GptResponseDto.class);
+        return response.choices().get(0).message().content(); // 영어 번역 결과 반환
+    }
+}
+
+

--- a/src/main/java/org/wefresh/wefresh_server/openAi/service/OpenAiService.java
+++ b/src/main/java/org/wefresh/wefresh_server/openAi/service/OpenAiService.java
@@ -8,10 +8,10 @@ import org.springframework.web.client.RestTemplate;
 import org.wefresh.wefresh_server.food.domain.Food;
 import org.wefresh.wefresh_server.food.manager.FoodRetriever;
 import org.wefresh.wefresh_server.openAi.dto.request.GptRequestDto;
-import org.wefresh.wefresh_server.openAi.dto.response.GptRecipeResponseDto;
-import org.wefresh.wefresh_server.openAi.dto.response.GptResponseDto;
-import org.wefresh.wefresh_server.openAi.dto.response.RecommendRecipesDto;
-import org.wefresh.wefresh_server.openAi.dto.response.TodayRecipesDto;
+import org.wefresh.wefresh_server.openAi.dto.response.gpt.GptRecipeResponseDto;
+import org.wefresh.wefresh_server.openAi.dto.response.gpt.GptResponseDto;
+import org.wefresh.wefresh_server.openAi.dto.response.gpt.RecommendRecipesDto;
+import org.wefresh.wefresh_server.openAi.dto.response.gpt.TodayRecipesDto;
 import org.wefresh.wefresh_server.openAi.util.JsonUtil;
 import org.wefresh.wefresh_server.recipe.domain.Recipe;
 import org.wefresh.wefresh_server.recipe.manager.RecipeSaver;
@@ -37,6 +37,7 @@ public class OpenAiService {
     private final FoodRetriever foodRetriever;
     private final RecipeSaver recipeSaver;
     private final TodayRecipeSaver todayRecipeSaver;
+    private final DallEService dallEService;
 
     @Transactional
     public RecommendRecipesDto getRecipe(final Long userId, final List<Long> foodIds) {
@@ -125,7 +126,7 @@ public class OpenAiService {
         return gptRecipes.recipes().stream()
                 .map(dto -> Recipe.builder()
                         .name(dto.name())
-                        .image("defaultImageURL")
+                        .image(dallEService.generateAndUploadImage(dto.name()))
                         .time(dto.time())
                         .calorie(dto.calorie())
                         .difficulty(dto.difficulty())
@@ -140,7 +141,7 @@ public class OpenAiService {
         return gptRecipes.recipes().stream()
                 .map(dto -> TodayRecipe.builder()
                         .name(dto.name())
-                        .image("defaultImageURL")
+                        .image(dallEService.generateAndUploadImage(dto.name()))
                         .time(dto.time())
                         .calorie(dto.calorie())
                         .difficulty(dto.difficulty())

--- a/src/main/java/org/wefresh/wefresh_server/recipe/domain/Recipe.java
+++ b/src/main/java/org/wefresh/wefresh_server/recipe/domain/Recipe.java
@@ -18,6 +18,7 @@ public class Recipe extends BaseTimeEntity implements RecipeBase {
 
     private String name;
 
+    @Column(length = 2083)
     private String image;
 
     private int time;

--- a/src/main/java/org/wefresh/wefresh_server/todayRecipe/domain/TodayRecipe.java
+++ b/src/main/java/org/wefresh/wefresh_server/todayRecipe/domain/TodayRecipe.java
@@ -20,6 +20,7 @@ public class TodayRecipe extends BaseTimeEntity implements RecipeBase {
 
     private String name;
 
+    @Column(length = 2083)
     private String image;
 
     private int time;


### PR DESCRIPTION
## 📚개요
[//]: # (해당하는 이슈 번호 달아주기)
- closed #43 

## 💡Key Changes
- 레시피 추천시 이미지를 DALL-E 이용하여 생성하도록 했습니다.
- DALL-E가 영어만 지원하여, 레시피 이름을 영어로 번역하여 DALL-E에게 요청하도록 했습니다.
- DALL-E로 생성한 url은 1시간 후에 만료되어, 이를 S3에 업로드하여 영구적으로 확인할 수 있도록 했습니다.

## 🎓Reference

